### PR TITLE
Update 08-defensive.md

### DIFF
--- a/08-defensive.md
+++ b/08-defensive.md
@@ -24,7 +24,7 @@ and how to tell if it's *still* getting the right answer
 as we make changes to it.
 
 To achieve that,
-we need to:
+we need to perform three operations:
 
 *   Write programs that check their own operation.
 *   Write and run tests for widely-used functions.


### PR DESCRIPTION
On line 27, there is a small grammatical error:

" To achieve that, we need to: "

A colon should only ever follow an independent clause, and the proposed fix is below: 

" To achieve that, we need to perform three operations: "
